### PR TITLE
Bugfix/focus on typeahead input

### DIFF
--- a/addon/components/power-select-typeahead/selected.js
+++ b/addon/components/power-select-typeahead/selected.js
@@ -33,11 +33,11 @@ export default Ember.Component.extend({
     e.stopPropagation();
   },
 
-  search(term, e) {
+  input(term, e) {
     this.get('select.actions.search')(term, e.target.value);
   },
 
-  keydown(e) {
+  keyDown(e) {
     let select = this.get('select');
     if (!select.isOpen) {
       e.stopPropagation();

--- a/addon/components/power-select-typeahead/selected.js
+++ b/addon/components/power-select-typeahead/selected.js
@@ -28,6 +28,7 @@ export default Ember.Component.extend({
 
   keydown(e) {
     let select = this.get('select');
+    if (!select.isOpen) {
       e.stopPropagation();
       return;
     }

--- a/addon/components/power-select-typeahead/selected.js
+++ b/addon/components/power-select-typeahead/selected.js
@@ -33,8 +33,8 @@ export default Ember.Component.extend({
     e.stopPropagation();
   },
 
-  input(term, e) {
-    this.get('select.actions.search')(term, e.target.value);
+  input(e) {
+    this.get('select.actions.search')(e.target.value);
   },
 
   keyDown(e) {

--- a/addon/components/power-select-typeahead/selected.js
+++ b/addon/components/power-select-typeahead/selected.js
@@ -25,7 +25,7 @@ export default Ember.Component.extend({
     } else {
       return 'blur';
     }
-  },
+  }),
 
   // Events
   click(e) {

--- a/addon/components/power-select-typeahead/selected.js
+++ b/addon/components/power-select-typeahead/selected.js
@@ -5,7 +5,9 @@ const { get, run, isBlank } = Ember;
 
 export default Ember.Component.extend({
   layout: layout,
-  tagName: '',
+  tagName: 'input',
+
+  classNames: 'ember-power-select-typeahead-input',
 
   // Observers
   optionsObserver: Ember.observer('options.length', function() {
@@ -16,29 +18,25 @@ export default Ember.Component.extend({
     }
   }),
 
-  // Actions
-  actions: {
-    captureClick(e) {
+  captureClick(e) {
+    e.stopPropagation();
+  },
+
+  search(term, e) {
+    this.get('select.actions.search')(term, e.target.value);
+  },
+
+  keydown(e) {
+    let select = this.get('select');
       e.stopPropagation();
-    },
-
-    search(term, e) {
-      this.get('select.actions.search')(term, e);
-    },
-
-    handleKeydown(e) {
-      let select = this.get('select');
-      if (!select.isOpen) {
-        e.stopPropagation();
-        return;
-      }
-      let term = e.target.value;
-      if (e.keyCode === 9) {
-        select.actions.select(this.get('highlighted'), e);
-      }
-      if (term.length === 0) {
-        e.stopPropagation();
-      }
+      return;
+    }
+    let term = e.target.value;
+    if (e.keyCode === 9) {
+      select.actions.select(this.get('highlighted'), e);
+    }
+    if (term.length === 0) {
+      e.stopPropagation();
     }
   }
 });

--- a/addon/components/power-select-typeahead/selected.js
+++ b/addon/components/power-select-typeahead/selected.js
@@ -18,7 +18,18 @@ export default Ember.Component.extend({
     }
   }),
 
-  captureClick(e) {
+  // Computed Properties
+  inputAction: Ember.computed('select.isOpen', function() {
+    if (this.get('select.isOpen')) {
+      return 'focus';
+    } else {
+      return 'blur';
+    }
+  },
+
+  // Events
+  click(e) {
+    this.$()[this.get('inputAction')]();
     e.stopPropagation();
   },
 

--- a/addon/templates/components/power-select-typeahead/selected.hbs
+++ b/addon/templates/components/power-select-typeahead/selected.hbs
@@ -1,7 +1,3 @@
-<input type="text" value={{if extra.labelPath (get selection extra.labelPath) selection}} class="ember-power-select-typeahead-input"
-  oninput={{action "search" value="target.value"}}
-  onkeydown={{action "handleKeydown"}}
-  onclick={{action "captureClick"}}>
 {{#if options.isPending}}
   <span class="ember-power-select-typeahead-loading-indicator"></span>
 {{/if}}


### PR DESCRIPTION
Because of `captureClick` it was very difficult to get the `input` element in the `selected` component to focus and blur correctly. With this change, the `selected` component itself becomes the `input` element. And we toggle `blur` and `focus` based on `select.isOpen`.