### PR TITLE
Update to Ember Power Select 0.8.0 (beta)

### DIFF
--- a/addon/components/power-select-typeahead.js
+++ b/addon/components/power-select-typeahead.js
@@ -4,7 +4,7 @@ import layout from '../templates/components/power-select-typeahead';
 export default Ember.Component.extend({
   layout: layout,
   tabindex: -1,
-  selectedComponent: 'power-select-typeahead/selected',
+  triggerComponent: 'power-select-typeahead/trigger',
   searchEnabled: false,
   loadingMessage: false,
 

--- a/addon/components/power-select-typeahead/trigger.js
+++ b/addon/components/power-select-typeahead/trigger.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import layout from '../../templates/components/power-select-typeahead/selected';
+import layout from '../../templates/components/power-select-typeahead/trigger';
 
 export default Ember.Component.extend({
   layout: layout,
@@ -31,8 +31,8 @@ export default Ember.Component.extend({
         return;
       }
       let term = e.target.value;
-      if (e.keyCode === 9) {
-        select.actions.select(this.get('highlighted'), e);
+      if (e.keyCode === 9 || e.keyCode === 13) {
+        select.actions.choose(this.get('highlighted'), e);
       }
       if (term.length === 0) {
         e.stopPropagation();

--- a/addon/templates/components/power-select-typeahead.hbs
+++ b/addon/templates/components/power-select-typeahead.hbs
@@ -1,9 +1,9 @@
 {{#power-select options=options selected=selected onchange=onchange disabled=disabled
     placeholder=placeholder searchEnabled=searchEnabled searchPlaceholder=searchPlaceholder
     loadingMessage=loadingMessage noMatchesMessage=noMatchesMessage searchMessage=searchMessage
-    selectedComponent=selectedComponent optionsComponent=optionsComponent matcher=matcher
+    triggerComponent=triggerComponent optionsComponent=optionsComponent matcher=matcher
     searchField=searchField renderInPlace=renderInPlace search=search allowClear=allowClear
-    dropdownPosition=dropdownPosition closeOnSelect=closeOnSelect class=concatenatedClasses
+    verticalPosition=verticalPosition closeOnSelect=closeOnSelect class=concatenatedClasses
     tabindex=tabindex extra=extra as |option|}}
 
     {{yield option}}

--- a/addon/templates/components/power-select-typeahead/trigger.hbs
+++ b/addon/templates/components/power-select-typeahead/trigger.hbs
@@ -1,4 +1,4 @@
-<input type="text" value={{if extra.labelPath (get selection extra.labelPath) selection}} class="ember-power-select-typeahead-input"
+<input type="text" value={{if extra.labelPath (get selected extra.labelPath) selected}} class="ember-power-select-typeahead-input"
   oninput={{action "search" value="target.value"}}
   onkeydown={{action "handleKeydown"}}
   onmousedown={{action "captureMouseDown"}}>

--- a/app/components/power-select-typeahead/selected.js
+++ b/app/components/power-select-typeahead/selected.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-power-select-typeahead/components/power-select-typeahead/selected';

--- a/app/components/power-select-typeahead/trigger.js
+++ b/app/components/power-select-typeahead/trigger.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-power-select-typeahead/components/power-select-typeahead/trigger';

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-export-application-global": "^1.0.4",
     "ember-get-helper": "1.0.4",
     "ember-pagefront": "0.8.2",
-    "ember-power-select": "^0.7.2",
+    "ember-power-select": "^0.8.0-beta.7",
     "ember-try": "~0.0.8"
   },
   "keywords": [


### PR DESCRIPTION
This upgrades to depend on ember-power-select 0.8.0-beta.7 or greater.
This version of EPS improves the API for component composition but also
introduces a couple backwards-incompatible changes.

Notably:

* The `selectedComponent` is now named `triggerComponent`, to be more aligned with its
  real role, the css class names and avoid confusion with the new `selectedItemComponent`.
  The old property continues to work but throws a deprecation warning.
* From within the `triggerComponent` the selected value is named `selected` (instead of
  `selection`) to be more aligned with the public API, where it's called `selected` too.
* `dropdownPosition` is now called `verticalPosition` (because now there is an horizontal one)