### PR TITLE
Handle focus on typeahead input

### DIFF
--- a/addon/templates/components/power-select-typeahead/trigger.hbs
+++ b/addon/templates/components/power-select-typeahead/trigger.hbs
@@ -2,6 +2,7 @@
   value={{if extra.labelPath (get selected extra.labelPath) selected}}
   class="ember-power-select-typeahead-input"
   oninput={{action handleInput}}
+  onfocus={{action handleFocus}}
   onkeydown={{action "handleKeydown"}}
   onmousedown={{action "stopPropagation"}}>
 {{#if loading}}


### PR DESCRIPTION
Will trigger focus actions passed to the component when focusing the typeahead input.

Pair PR for `ember-power-select` to make the `handleFocus` action.