### PR TITLE
Show placeholder text on input field

### DIFF
--- a/addon/templates/components/power-select-typeahead/trigger.hbs
+++ b/addon/templates/components/power-select-typeahead/trigger.hbs
@@ -1,6 +1,7 @@
 <input type="search"
   value={{text}}
   class="ember-power-select-typeahead-input ember-power-select-search-input"
+  placeholder={{placeholder}}
   oninput={{action "handleInputLocal"}}
   onfocus={{action handleFocus}}
   onkeydown={{action "handleKeydown"}}


### PR DESCRIPTION
Seems the typeahead component is not set up to show placeholder text. 

This change will display the placeholder text on the typeahead input field if no value is present.