### PR TITLE
Bugfix/touchevents

### DIFF
--- a/addon/components/power-select-typeahead.js
+++ b/addon/components/power-select-typeahead.js
@@ -2,6 +2,10 @@ import Ember from 'ember';
 import layout from '../templates/components/power-select-typeahead';
 const { computed } = Ember;
 
+function handleTouchEvent(e) {
+  e.stopPropagation();
+}
+
 export default Ember.Component.extend({
   layout: layout,
   tabindex: -1,
@@ -27,5 +31,21 @@ export default Ember.Component.extend({
       classes.push(passedClass);
     }
     return classes.join(' ');
-  })
+  }),
+
+  didInsertElement() {
+    this._super(...arguments);
+
+    let input = this.$('.ember-power-select-typeahead-input').get(0);
+    input.addEventListener('touchstart', handleTouchEvent, false);
+    input.addEventListener('touchend', handleTouchEvent, false);
+  },
+
+  willDestroyElement() {
+    this._super(...arguments);
+
+    let input = this.$('.ember-power-select-typeahead-input').get(0);
+    input.removeEventListener('touchstart', handleTouchEvent, false);
+    input.removeEventListener('touchend', handleTouchEvent, false);
+  }
 });

--- a/addon/templates/components/power-select-typeahead.hbs
+++ b/addon/templates/components/power-select-typeahead.hbs
@@ -11,7 +11,7 @@
       dir=dir
       destination=destination
       disabled=disabled
-      dropdownClass=concatenatedDropdownClass
+      dropdownClass=concatenatedDropdownClasses
       extra=extra
       horizontalPosition=horizontalPosition
       initiallyOpened=initiallyOpened
@@ -38,7 +38,7 @@
       selected=selected
       selectedItemComponent=selectedItemComponent
       tabindex=tabindex
-      triggerClass=concatenatedTriggerClass
+      triggerClass=concatenatedTriggerClasses
       triggerComponent=triggerComponent
       verticalPosition=verticalPosition
       as |option term|}}
@@ -59,7 +59,7 @@
       dir=dir
       destination=destination
       disabled=disabled
-      dropdownClass=concatenatedDropdownClass
+      dropdownClass=concatenatedDropdownClasses
       extra=extra
       horizontalPosition=horizontalPosition
       initiallyOpened=initiallyOpened
@@ -86,7 +86,7 @@
       selected=selected
       selectedItemComponent=selectedItemComponent
       tabindex=tabindex
-      triggerClass=concatenatedTriggerClass
+      triggerClass=concatenatedTriggerClasses
       triggerComponent=triggerComponent
       verticalPosition=verticalPosition
       as |option term|}}


### PR DESCRIPTION
This fixes   an issue where touch events on the input activate the dropdown. I tried to use the existing _stopPropagation_ action on the trigger, but couldn't get that to work. ¯\_(ツ)_/¯ Thoughts on why `ontouchstart={{action "stopPropagation"}}` wasn't good enough?

Should also fix #21. 🍻 
