### PR TITLE
Make power-select-typeahead tagless

### DIFF
--- a/addon/components/power-select-typeahead.js
+++ b/addon/components/power-select-typeahead.js
@@ -3,6 +3,7 @@ import layout from '../templates/components/power-select-typeahead';
 const { computed } = Ember;
 
 export default Ember.Component.extend({
+  tagName: '',
   layout: layout,
   tabindex: -1,
   triggerComponent: 'power-select-typeahead/trigger',


### PR DESCRIPTION
I noticed that this wasn't a tagless component when I switched from a regular power-select to this one.  I'm thinking that was just an oversight.  

Included is a one line change that makes it tagless like the other power-select variations.  