### PR TITLE
fix concatenatedDropdownClasses typo

### DIFF
--- a/addon/templates/components/power-select-typeahead.hbs
+++ b/addon/templates/components/power-select-typeahead.hbs
@@ -11,7 +11,7 @@
       dir=dir
       destination=destination
       disabled=disabled
-      dropdownClass=concatenatedDropdownClass
+      dropdownClass=concatenatedDropdownClasses
       extra=extra
       horizontalPosition=horizontalPosition
       initiallyOpened=initiallyOpened


### PR DESCRIPTION
computed property for concatenated drop down classes is defined as `concatenatedDropdownClasses` but on the template it's `concatenatedDropdownClass`.  