### PR TITLE
Allow usage without EPS as a direct dependency of the app.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,12 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-power-select-typeahead'
+  name: 'ember-power-select-typeahead',
+
+  contentFor: function(type, config) {
+    var emberPowerSelect = this.addons.filter(function(addon) {
+      return addon.name === 'ember-power-select';
+    })[0]
+    return emberPowerSelect.contentFor(type, config);
+  }
 };


### PR DESCRIPTION
The content-for hook is idempotent, so there is nothing wrong in calling it twice.