### PR TITLE
Pass `calculatePosition` as option into EPS

### DIFF
--- a/addon/templates/components/power-select-typeahead.hbs
+++ b/addon/templates/components/power-select-typeahead.hbs
@@ -44,6 +44,7 @@
       triggerComponent=triggerComponent
       triggerId=triggerId
       verticalPosition=verticalPosition
+      calculatePosition=calculatePosition
       as |option term|}}
       {{yield option term}}
     {{else}}
@@ -95,6 +96,7 @@
       triggerComponent=triggerComponent
       triggerId=triggerId
       verticalPosition=verticalPosition
+      calculatePosition=calculatePosition
       as |option term|}}
       {{yield option term}}
   {{/power-select}}


### PR DESCRIPTION
I found it helpful on a recent project to calculate the position on the dropdown menu manually. Adding `calculatePosition` would also conform to the ember basic dropdown API.