### PR TITLE
Fix Screenreader issue from #67

### DIFF
--- a/addon/templates/components/power-select-typeahead.hbs
+++ b/addon/templates/components/power-select-typeahead.hbs
@@ -44,6 +44,7 @@
       triggerClass=concatenatedTriggerClasses
       triggerComponent=triggerComponent
       triggerId=triggerId
+      triggerRole=null
       verticalPosition=verticalPosition
       as |option term|}}
       {{yield option term}}
@@ -96,6 +97,7 @@
       triggerClass=concatenatedTriggerClasses
       triggerComponent=triggerComponent
       triggerId=triggerId
+      triggerRole=null
       verticalPosition=verticalPosition
       as |option term|}}
       {{yield option term}}

--- a/addon/templates/components/power-select-typeahead/trigger.hbs
+++ b/addon/templates/components/power-select-typeahead/trigger.hbs
@@ -1,5 +1,6 @@
 <input type="search"
   value={{text}}
+  role="combobox"
   id="ember-power-select-typeahead-input-{{select.uniqueId}}"
   class="ember-power-select-typeahead-input ember-power-select-search-input"
   autocomplete="off"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "ember-cli-babel": "^6.3.0",
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-power-select": "^1.9.7"
+    "ember-power-select": "^1.10.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/tests/integration/components/power-select-typeahead-test.js
+++ b/tests/integration/components/power-select-typeahead-test.js
@@ -72,11 +72,11 @@ test('can search async with loading message', function(assert) {
   };
   this.loadingMessage = 'searching...';
   this.render(hbs`
-    {{#power-select-typeahead 
+    {{#power-select-typeahead
       search=searchCountriesAsync
-      selected=selected 
+      selected=selected
       loadingMessage=loadingMessage
-      onchange=(action (mut selected)) 
+      onchange=(action (mut selected))
       extra=(hash labelPath="name") as |country|}}
       {{country.name}}
     {{/power-select-typeahead}}
@@ -104,10 +104,10 @@ test('search async with no loading message', function(assert) {
     });
   };
   this.render(hbs`
-    {{#power-select-typeahead 
+    {{#power-select-typeahead
       search=searchCountriesAsync
-      selected=selected 
-      onchange=(action (mut selected)) 
+      selected=selected
+      onchange=(action (mut selected))
       extra=(hash labelPath="name") as |country|}}
       {{country.name}}
     {{/power-select-typeahead}}
@@ -136,11 +136,11 @@ test('search async with noMatchesMessage', function(assert) {
   };
   this.noMatchesMessage = 'no matches homie';
   this.render(hbs`
-    {{#power-select-typeahead 
+    {{#power-select-typeahead
       search=searchCountriesAsync
-      selected=selected 
+      selected=selected
       noMatchesMessage=noMatchesMessage
-      onchange=(action (mut selected)) 
+      onchange=(action (mut selected))
       extra=(hash labelPath="name") as |country|}}
       {{country.name}}
     {{/power-select-typeahead}}
@@ -162,10 +162,10 @@ test('search async without noMatchesMessage', function(assert) {
     });
   };
   this.render(hbs`
-    {{#power-select-typeahead 
+    {{#power-select-typeahead
       search=searchCountriesAsync
-      selected=selected 
-      onchange=(action (mut selected)) 
+      selected=selected
+      onchange=(action (mut selected))
       extra=(hash labelPath="name") as |country|}}
       {{country.name}}
     {{/power-select-typeahead}}
@@ -185,10 +185,10 @@ test('search async with no text will open and then close dropdown', function(ass
     });
   };
   this.render(hbs`
-    {{#power-select-typeahead 
+    {{#power-select-typeahead
       search=searchCountriesAsync
-      selected=selected 
-      onchange=(action (mut selected)) 
+      selected=selected
+      onchange=(action (mut selected))
       extra=(hash labelPath="name") as |country|}}
       {{country.name}}
     {{/power-select-typeahead}}
@@ -198,4 +198,15 @@ test('search async with no text will open and then close dropdown', function(ass
   assert.ok(find('.ember-power-select-dropdown'), 'The component is opened');
   typeInSearch('');
   assert.notOk(find('.ember-power-select-dropdown'), 'The component is closed');
+});
+
+test('The dropdown doesnt have a "button" role', function(assert) {
+  assert.expect(1);
+  this.numbers = numbers;
+  this.render(hbs`
+    {{#power-select-typeahead options=numbers selected=selected onchange=(action (mut selected)) as |number|}}
+      {{number}}
+    {{/power-select-typeahead}}
+  `);
+  assert.notOk(find('.ember-power-select-trigger').getAttribute('role'), 'The trigger does not have button role');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,6 +993,10 @@ bower-endpoint-parser@0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz#00b565adbfab6f2d35addde977e97962acbcb3f6"
 
+bower@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/bower/-/bower-1.8.2.tgz#adf53529c8d4af02ef24fb8d5341c1419d33e2f7"
+
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
@@ -2000,13 +2004,13 @@ electron-to-chromium@^1.3.18:
   version "1.3.21"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz#a967ebdcfe8ed0083fc244d1894022a8e8113ea2"
 
-ember-basic-dropdown@^0.33.1:
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-0.33.5.tgz#39986d4cc6732edf43fb51eabb70790e99e8ae2c"
+ember-basic-dropdown@^0.33.9:
+  version "0.33.9"
+  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-0.33.9.tgz#09db10b1588845f0603fce0879edf5c0db9c6136"
   dependencies:
-    ember-cli-babel "^6.8.1"
+    ember-cli-babel "^6.8.2"
     ember-cli-htmlbars "^2.0.3"
-    ember-native-dom-helpers "^0.5.3"
+    ember-native-dom-helpers "^0.5.4"
     ember-wormhole "^0.5.2"
 
 ember-cli-app-version@^2.0.0:
@@ -2016,7 +2020,7 @@ ember-cli-app-version@^2.0.0:
     ember-cli-babel "^6.8.0"
     git-repo-version "0.4.1"
 
-ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.6, ember-cli-babel@^5.2.1:
+ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.3, ember-cli-babel@^5.2.1:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
   dependencies:
@@ -2026,7 +2030,7 @@ ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.6, ember-cl
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.0.0-beta.9, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.0.0-beta.9, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
   dependencies:
@@ -2496,7 +2500,7 @@ ember-native-dom-helpers@^0.3.9:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.0.0-beta.9"
 
-ember-native-dom-helpers@^0.5.3:
+ember-native-dom-helpers@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.4.tgz#0bc1506a643fb7adc0abf1d09c44a7914459296b"
   dependencies:
@@ -2518,16 +2522,17 @@ ember-pagefront@0.11.2:
     open "0.0.5"
     prompt "^0.2.14"
 
-ember-power-select@^1.9.7:
-  version "1.9.7"
-  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-1.9.7.tgz#5b1d739f170dc42e25ada741c5373dd5b88d0ae2"
+ember-power-select@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-1.10.1.tgz#c4978638b78a82a895a79e3231f1e7a25b18e86c"
   dependencies:
-    ember-basic-dropdown "^0.33.1"
-    ember-cli-babel "^6.6.0"
+    bower "^1.8.2"
+    ember-basic-dropdown "^0.33.9"
+    ember-cli-babel "^6.8.2"
     ember-cli-htmlbars "^2.0.1"
     ember-concurrency "^0.8.1"
-    ember-text-measurer "^0.3.3"
-    ember-truth-helpers "^1.3.0"
+    ember-text-measurer "^0.4.0"
+    ember-truth-helpers "^2.0.0"
 
 ember-qunit@^2.2.0:
   version "2.2.0"
@@ -2579,17 +2584,17 @@ ember-test-helpers@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz#f864cdf6f4e75f3f8768d6537785b5ab6e82d907"
 
-ember-text-measurer@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/ember-text-measurer/-/ember-text-measurer-0.3.3.tgz#0762809a71c2e1f2e60ab00c53c6eb1b63c9f963"
+ember-text-measurer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/ember-text-measurer/-/ember-text-measurer-0.4.0.tgz#a676195378d4eb4c1617678c2d198a2344b4d12b"
   dependencies:
-    ember-cli-babel "^5.1.6"
+    ember-cli-babel "^6.8.2"
 
-ember-truth-helpers@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-1.3.0.tgz#6ed9f83ce9a49f52bb416d55e227426339a64c60"
+ember-truth-helpers@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-2.0.0.tgz#f3e2eef667859197f1328bb4f83b0b35b661c1ac"
   dependencies:
-    ember-cli-babel "^5.1.6"
+    ember-cli-babel "^6.8.2"
 
 ember-try-config@^2.0.1:
   version "2.1.0"


### PR DESCRIPTION
A new version of `ember-power-select` accepts a `triggerRole`
attribute which makes it possible to remove the `role="button"`
that was on the trigger element, preventing screenreaders from
typing

- [x] Waiting on https://github.com/cibernox/ember-power-select/pull/1009 to be merged, before we can bump the power-select version and merge this PR.