### PR TITLE
Add preventScroll to options passed through to power-select

### DIFF
--- a/addon/templates/components/power-select-typeahead.hbs
+++ b/addon/templates/components/power-select-typeahead.hbs
@@ -32,6 +32,7 @@
       options=options
       optionsComponent=optionsComponent
       placeholder=placeholder
+      preventScroll=preventScroll
       renderInPlace=renderInPlace
       search=search
       searchEnabled=searchEnabled
@@ -86,6 +87,7 @@
       options=options
       optionsComponent=optionsComponent
       placeholder=placeholder
+      preventScroll=preventScroll
       renderInPlace=renderInPlace
       search=search
       searchEnabled=searchEnabled


### PR DESCRIPTION
Not sure if there is a specific reason `preventScroll` was left out, but it definitely helps fix an issue we have with the typeahead, so hopefully an oversight or just not yet introduced.