### PR TITLE
Add animationEnabled to pass it through power-select

### DIFF
--- a/addon/templates/components/power-select-typeahead.hbs
+++ b/addon/templates/components/power-select-typeahead.hbs
@@ -2,6 +2,7 @@
   {{#power-select
       afterOptionsComponent=afterOptionsComponent
       allowClear=allowClear
+      animationEnabled=animationEnabled
       ariaDescribedBy=ariaDescribedBy
       ariaInvalid=ariaInvalid
       ariaLabel=ariaLabel
@@ -58,6 +59,7 @@
   {{#power-select
       afterOptionsComponent=afterOptionsComponent
       allowClear=allowClear
+      animationEnabled=animationEnabled
       ariaDescribedBy=ariaDescribedBy
       ariaInvalid=ariaInvalid
       ariaLabel=ariaLabel


### PR DESCRIPTION
Need to pass in `animationEnabled` property through typeahead.

Been running into ember run loop errors related to animating dropdown when the component has already been destroyed, as it's scheduled `afterRender` here - https://github.com/cibernox/ember-basic-dropdown/blob/master/addon/components/basic-dropdown/content.js#L183

Will be creating another PR in ember-power-select to let this property pass down to ember-basic-dropdown. 
