### PR TITLE
Fix auto-correct in safari and other browsers

### DIFF
--- a/addon/templates/components/power-select-typeahead/trigger.hbs
+++ b/addon/templates/components/power-select-typeahead/trigger.hbs
@@ -4,6 +4,9 @@
   id="ember-power-select-typeahead-input-{{select.uniqueId}}"
   class="ember-power-select-typeahead-input ember-power-select-search-input"
   autocomplete="off"
+  autocorrect="off"
+  autocapitalize="off"
+  spellcheck="false"  
   placeholder={{placeholder}}
   oninput={{onInput}}
   onfocus={{onFocus}}


### PR DESCRIPTION
Also in line with:
https://github.com/cibernox/ember-power-select/blob/7ffe3f0a3d2fdc7132b3bf991245d93610f0ef7c/addon/templates/components/power-select/before-options.hbs