### PR TITLE
Updates the README.md with information about the supported power-select version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Naive implementation of a typeahead component on top of ember-power-select.
 
 ## Installation
 
+**Requires ember-power-select v2.0+!**
+
+For ember-power-select v1.x use [v.6.1](https://github.com/cibernox/ember-power-select-typeahead/tree/v0.6.1)
+
+
 ```
 ember install ember-power-select-typeahead
 ```


### PR DESCRIPTION
Hi there,
I've spent a while trying to figure out why the add-on doesnt work for me, and took me a while to realize the latest version only supports ember-power-select v2.0+
While it might be my fault for not checking the package.json, I feel like it's worthwhile to update the readme with this information for better user experience